### PR TITLE
Bug Fix: Staked tokens was incorrect

### DIFF
--- a/src/components/Capacity.svelte
+++ b/src/components/Capacity.svelte
@@ -33,7 +33,7 @@
         { label: 'Remaining', value: balanceToHuman(capacityDetails?.remainingCapacity, 'CAP') },
         { label: 'Total Issued', value: balanceToHuman(capacityDetails?.totalCapacityIssued, 'CAP') },
         { label: 'Last Replenished', value: `Epoch ${capacityDetails?.lastReplenishedEpoch}` },
-        { label: 'Staked Token', value: balanceToHuman(capacityDetails?.totalCapacityIssued, $storeChainInfo.token) },
+        { label: 'Staked Token', value: balanceToHuman(capacityDetails?.totalTokensStaked, $storeChainInfo.token) },
       ];
     }
   }

--- a/src/components/Provider.svelte
+++ b/src/components/Provider.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { dotApi, storeChainInfo } from '$lib/stores';
   import { user } from '$lib/stores/userStore';
+  import { activityLog } from '$lib/stores/activityLogStore';
   import { balanceToHuman } from '$lib/utils';
   import { getBalances } from '$lib/polkadotApi';
   import type { AccountBalances } from '$lib/polkadotApi';
@@ -11,6 +12,9 @@
   let isAddKeyOpen: boolean = false;
 
   $: {
+    // Easy way to tag a subscription onto this action.
+    // This way we update the information when the log updates
+    const _triggerReloadOnLogUpdate = $activityLog;
     if ($dotApi.api) {
       getBalances($dotApi.api, $user.address).then((info) => (accountBalances = info));
     }


### PR DESCRIPTION
## Goal

The goal of this PR is to do a quick bug fix on staked tokens, which before was just showing capacity instead of staked tokens.

Also make account balances update when the activity log updates

## Checklist

- [x] PR Self-Review and Commenting
- ~Docs updated~
- ~Tests added~

## How To Test the Changes

1. Clone the pr branch
2. Login as a provider
3. Stake tokens
4. See that the Provider -> Locked changes
5. See that the Capacity -> Staked Token is correctly 50x larger than the capacity and likely matches the Locked value
