### PR TITLE
global rename all 'control key' 'wallet address' etc to account id

### DIFF
--- a/src/components/AddAccountId.svelte
+++ b/src/components/AddAccountId.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { dotApi } from '$lib/stores';
   import type { ApiPromise } from '@polkadot/api';
-  import { submitAddControlKey } from '$lib/connections';
+  import { submitAddAccountId } from '$lib/connections';
   import { getExtension } from '$lib/utils';
   import AddKeyRequirements from './AddKeyRequirements.svelte';
   import Modal from './Modal.svelte';
@@ -17,14 +17,14 @@
 
   $: isSubmitDisabled = selectedAccount?.injectedAccount == null;
 
-  const addControlKey = async () => {
+  const addAccountId = async () => {
     if (!selectedAccount || !selectedAccount.injectedAccount) {
-      alert('Please choose a key to add.');
+      alert('Please choose an Account Id to add.');
     } else if (!$user.msaId || !$user.injectedAccount) {
       alert('Invalid provider.');
     } else {
       close();
-      await submitAddControlKey(
+      await submitAddAccountId(
         $dotApi.api as ApiPromise,
         await getExtension($user),
         selectedAccount,
@@ -40,17 +40,17 @@
   }
 </script>
 
-<Modal id="add-control-key" {isOpen} close={onCancel}>
+<Modal id="add-account-id" {isOpen} close={onCancel}>
   <span slot="title">
-    Add a Key to MSA (<span class="font-light">{$user.msaId}</span>)
+    Add an Account Id to MSA (<span class="font-light">{$user.msaId}</span>)
   </span>
 
   <svelte:fragment slot="body">
     <form class="column">
       <DropDownMenu
-        id="AddControlKey"
-        label="Key to Add"
-        placeholder="Select Key..."
+        id="AddAccountId"
+        label="Account Id to Add"
+        placeholder="Select Id..."
         bind:value={selectedAccount}
         options={Array.from($unusedKeyAccountsStore.values()) || []}
         disabled={$unusedKeyAccountsStore.size === 0}
@@ -58,11 +58,13 @@
       />
       {#if $unusedKeyAccountsStore.size === 0}
         <div id="network-error-msg" class="text-sm text-error">
-          No available keys. Create a new account without an MSA Id.
+          No available Account Ids. Create a new Account Id without an MSA Id.
         </div>
       {/if}
       <div class="flex w-[350px] justify-between">
-        <button on:click|preventDefault={addControlKey} class="btn-primary" disabled={isSubmitDisabled}>Add Key</button>
+        <button on:click|preventDefault={addAccountId} class="btn-primary" disabled={isSubmitDisabled}
+          >Add Account Id</button
+        >
         <button on:click|preventDefault={onCancel} class="btn-no-fill">Cancel</button>
       </div>
     </form>

--- a/src/components/AddKeyRequirements.svelte
+++ b/src/components/AddKeyRequirements.svelte
@@ -2,17 +2,17 @@
   <div class="label mb-2">Requirements</div>
   <ol class="ordered-list text-xs">
     <li>
-      Ensure the new control key has a FRQCY balance if you intend to use it for submitting FRQCY or Capacity
+      Ensure the new Account Id has a FRQCY balance if you intend to use it for submitting FRQCY or Capacity
       transactions.
     </li>
-    <li>If using a wallet, ensure the new control key is imported into your wallet.</li>
-    <li>Select the new control key from the dropdown list below.</li>
+    <li>If using a wallet, ensure the new Account Id is imported into your wallet.</li>
+    <li>Select the new Account Id from the dropdown list below.</li>
     <li>Click 'Add It.'</li>
     <li>This requires 3 signatures: two for the authorization payload, and one to send the transaction.</li>
     <ul class="unordered-list">
-      <li>Sign with the new control key,</li>
-      <li>Sign with the current control key,</li>
-      <li>Sign the transaction with the current control key.</li>
+      <li>Sign with the new Account Id,</li>
+      <li>Sign with the current Account Id,</li>
+      <li>Sign the transaction with the current Account Id.</li>
     </ul>
   </ol>
 </div>

--- a/src/components/BecomeAProvider.svelte
+++ b/src/components/BecomeAProvider.svelte
@@ -20,9 +20,9 @@
       <SelectNetworkAndAccount
         bind:newUser={$user}
         accounts={$nonProviderAccountsStore}
-        accountSelectorTitle="Wallet Address"
-        accountSelectorPlaceholder="Select a wallet address"
-        noAccountsFoundErrorMsg="No accounts found.  Add an account to your wallet."
+        accountSelectorTitle="Account Id"
+        accountSelectorPlaceholder="Select an Account Id"
+        noAccountsFoundErrorMsg="No accounts found.  Add an Account Id to your wallet."
       />
       {#if $user?.network != null && $user.network.name === 'MAINNET'}
         <EmailProviderRequest />
@@ -41,7 +41,8 @@
     <div class="text-sm">
       For developer and testing convenience, on Testnet, anyone with an MSA who wishes to become a Provider may simply
       submit a createProvider transaction.<br /><br />This action will register the MSA Id that is controlled by the
-      selected Transaction Signing Address above. Any control key for the MSA Id can submit the transaction.
+      selected Transaction Signing Address above. Any Account Id that has been added to the MSA can submit the
+      transaction.
     </div>
   </BlockSection>
 </div>

--- a/src/components/LoginForm.svelte
+++ b/src/components/LoginForm.svelte
@@ -26,9 +26,9 @@
 <SelectNetworkAndAccount
   bind:newUser
   accounts={$providerAccountsStore}
-  accountSelectorTitle="Select a Provider Control Key"
-  accountSelectorPlaceholder="Select a provider control key"
-  noAccountsFoundErrorMsg="No provider accounts found.  Become a provider?"
+  accountSelectorTitle="Select an Account Id"
+  accountSelectorPlaceholder="Select a Provider Account Id"
+  noAccountsFoundErrorMsg="No Provider Account Ids found.  Become a Provider?"
 />
 <div class="flex justify-between align-bottom">
   <Button id="connect-button" title="Connect" disabled={!canConnect} action={connect} />

--- a/src/components/Provider.svelte
+++ b/src/components/Provider.svelte
@@ -6,10 +6,10 @@
   import { getBalances } from '$lib/polkadotApi';
   import type { AccountBalances } from '$lib/polkadotApi';
   import ListCard from './ListCard.svelte';
-  import AddControlKey from './AddControlKey.svelte';
+  import AddAccountId from './AddAccountId.svelte';
 
   let accountBalances: AccountBalances = { free: 0n, reserved: 0n, frozen: 0n };
-  let isAddKeyOpen: boolean = false;
+  let isAddAccountIdOpen: boolean = false;
 
   $: {
     // Easy way to tag a subscription onto this action.
@@ -38,6 +38,6 @@
 </script>
 
 <ListCard title="Provider" list={providerList} errorMessage={errMsg}>
-  <button on:click|preventDefault={() => (isAddKeyOpen = true)} class="btn-primary">Add control key</button>
-  <AddControlKey isOpen={isAddKeyOpen} close={() => (isAddKeyOpen = false)} />
+  <button on:click|preventDefault={() => (isAddAccountIdOpen = true)} class="btn-primary">Add Account Id</button>
+  <AddAccountId isOpen={isAddAccountIdOpen} close={() => (isAddAccountIdOpen = false)} />
 </ListCard>

--- a/src/components/Stake.svelte
+++ b/src/components/Stake.svelte
@@ -18,7 +18,7 @@
     <div>
       <div class="label mb-2">Requirements</div>
       <ol class="ordered-list text-xs">
-        <li>Ensure the control key has a <span class="units">{$storeChainInfo.token}</span> balance.</li>
+        <li>Ensure the Account Id has a <span class="units">{$storeChainInfo.token}</span> balance.</li>
         <li>Click 'Stake'.</li>
         <li>This will require 1 signature to send the transaction.</li>
       </ol>

--- a/src/components/StakeForm.svelte
+++ b/src/components/StakeForm.svelte
@@ -44,8 +44,8 @@
 
 <form class="column">
   <DropDownMenu
-    id="stake-using-key"
-    label="Wallet Address"
+    id="stake-using-account-id"
+    label="Wallet Account Id"
     bind:value={selectedAccount}
     options={Array.from($allAccountsStore.values())}
     formatter={formatAccount}

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -35,7 +35,7 @@ export async function getEpoch(api: ApiPromise): Promise<bigint> {
 }
 
 // creates the payloads and gets or creates the signatures, then submits the extrinsic
-export async function submitAddControlKey(
+export async function submitAddAccountId(
   api: ApiPromise,
   extension: InjectedExtension | undefined,
   newAccount: Account,

--- a/test/unit-and-integration/connections.test.ts
+++ b/test/unit-and-integration/connections.test.ts
@@ -3,7 +3,7 @@ import {
   getEpoch,
   signPayloadWithExtension,
   signPayloadWithKeyring,
-  submitAddControlKey,
+  submitAddAccountId,
 } from '../../src/lib/connections';
 import { describe, expect, test } from 'vitest';
 import { ApiPromise } from '@polkadot/api';
@@ -108,7 +108,7 @@ describe('getBlockNumber', () => {
     expect(bn).toBe(1001n);
   });
 });
-describe('submitAddControlKey', async () => {
+describe('submitAddAccountId', async () => {
   const keyring = new Keyring({ type: 'sr25519' });
   const keyRingPairA = keyring.addFromUri('//Alice');
   const keyRingPairB = keyring.addFromUri('//Bob');
@@ -126,7 +126,7 @@ describe('submitAddControlKey', async () => {
     const api = await ApiPromise.create();
     const extension = undefined;
     const msaId = 4;
-    await submitAddControlKey(api, extension, bob, alice, msaId);
+    await submitAddAccountId(api, extension, bob, alice, msaId);
     expect(api.tx.msa.addPublicKeyToMsa).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Goal

The goal of this PR is to unify naming of "wallet key", "control key" etc, to reflect what it's called on chain:  Account Id.  Changes names in code and in UI.   NO functionality has changed.

Closes #168 

## Checklist

- [x] PR Self-Review and Commenting
- [x] Docs updated

## How To Test the Changes
1. CI should be passing.
1. Clone the pr branch and `npm run dev`, connect to Paseo or a local Frequency chain and register as / connect a provider, attempt to add Account Ids, etc.
