### PR TITLE
Fix usage of the any type

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,6 @@ export default tseslint.config(
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-inferrable-types': 'off',
       '@typescript-eslint/consistent-type-assertions': 'off',
-      '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/src/components/AddToClipboard.svelte
+++ b/src/components/AddToClipboard.svelte
@@ -26,6 +26,7 @@
 
   const copy = () => {
     const app = new Clipboard({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       target: document.getElementById('clipboard')!,
       props: { copyValue },
     });

--- a/src/components/DropDownMenu.svelte
+++ b/src/components/DropDownMenu.svelte
@@ -1,11 +1,11 @@
-<script lang="ts" generics="T">
+<script lang="ts" generics="T extends { toString: () => string }">
   export let label: string;
   export let id: string = '';
   export let options: T[]; // eslint-disable-line no-undef
   export let value: T | null = null; // eslint-disable-line no-undef
   export let placeholder: string = '';
   export let onChange: (() => void) | undefined = undefined;
-  export let formatter: (value: any) => string = (value) => value.toString();
+  export let formatter: (value: T) => string = (value) => value.toString(); // eslint-disable-line no-undef
 </script>
 
 <div>

--- a/src/components/KeySelection.svelte
+++ b/src/components/KeySelection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let validAccounts: Record<string, any> = {};
+  export let validAccounts: Record<string, { meta: { name: string } }> = {};
   export let component = '';
   export let selectLabel = 'empty';
   export let selectedOption = '';

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -128,6 +128,7 @@ async function submitExtrinsicWithKeyring(
   return extrinsic.hash.toString();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function signPayload(payload: any, account: Account, extension: InjectedExtension | undefined): Promise<string> {
   if (account.keyringPair) return signPayloadWithKeyring(account.keyringPair, payload);
   if (extension) return await signPayloadWithExtension(extension, account.address, payload);
@@ -141,6 +142,7 @@ async function signPayload(payload: any, account: Account, extension: InjectedEx
 export async function signPayloadWithExtension(
   injector: InjectedExtension,
   signingPublicKey: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload: any
 ): Promise<string> {
   const signer = injector?.signer;
@@ -167,6 +169,7 @@ export async function signPayloadWithExtension(
 
 // Use the built-in Alice..Ferdie accounts to sign some data
 // returns a properly formatted signature to submit with an extrinsic
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function signPayloadWithKeyring(signingAccount: KeyringPair, payload: any): string {
   try {
     // u8aWrapBytes literally puts <Bytes></Bytes> around the payload.

--- a/src/lib/polkadotApi.ts
+++ b/src/lib/polkadotApi.ts
@@ -61,7 +61,7 @@ export async function getMsaInfo(apiPromise: ApiPromise, publicKey: string): Pro
     if (providerRegistry.isSome) {
       msaInfo.isProvider = true;
       const registryEntry = providerRegistry.unwrap();
-      msaInfo.providerName = registryEntry.providerName.toUtf8();
+      msaInfo.providerName = registryEntry.providerName.toString();
     }
   }
   return msaInfo;

--- a/src/lib/polkadotApi.ts
+++ b/src/lib/polkadotApi.ts
@@ -1,7 +1,6 @@
 import type { MsaInfo } from '$lib/storeTypes';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { ChainProperties } from '@polkadot/types/interfaces';
-import type { Option, u64 } from '@polkadot/types';
 import type { DotApi } from '$lib/storeTypes';
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
 import { options } from '@frequency-chain/api-augment';
@@ -54,15 +53,15 @@ export async function getBalances(apiPromise: ApiPromise, accountId: string): Pr
 }
 
 export async function getMsaInfo(apiPromise: ApiPromise, publicKey: string): Promise<MsaInfo> {
-  const received: u64 = (await apiPromise?.query.msa.publicKeyToMsaId(publicKey))?.unwrapOrDefault();
+  const received = (await apiPromise?.query.msa.publicKeyToMsaId(publicKey))?.unwrapOrDefault();
   const msaInfo: MsaInfo = { isProvider: false, msaId: 0, providerName: '' };
   msaInfo.msaId = received?.toNumber();
   if (msaInfo.msaId > 0) {
-    const providerRegistry: Option<any> = await apiPromise.query.msa.providerToRegistryEntry(msaInfo.msaId);
+    const providerRegistry = await apiPromise.query.msa.providerToRegistryEntry(msaInfo.msaId);
     if (providerRegistry.isSome) {
       msaInfo.isProvider = true;
       const registryEntry = providerRegistry.unwrap();
-      msaInfo.providerName = registryEntry.providerName;
+      msaInfo.providerName = registryEntry.providerName.toUtf8();
     }
   }
   return msaInfo;
@@ -83,10 +82,10 @@ export async function getCapacityInfo(apiPromise: ApiPromise, msaId: number): Pr
     lastReplenishedEpoch: 0n,
   };
 
-  const providerRegistry: Option<any> = await apiPromise.query.msa.providerToRegistryEntry(msaId);
+  const providerRegistry = await apiPromise.query.msa.providerToRegistryEntry(msaId);
 
   if (providerRegistry.isSome) {
-    const details: any = (await apiPromise.query.capacity.capacityLedger(msaId)).unwrapOrDefault();
+    const details = (await apiPromise.query.capacity.capacityLedger(msaId)).unwrapOrDefault();
     capacityDetails = {
       remainingCapacity: details.remainingCapacity.toBigInt(),
       totalTokensStaked: details.totalTokensStaked.toBigInt(),

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -1,11 +1,12 @@
 import type { ApiPromise, WsProvider } from '@polkadot/api';
 import type { Keyring } from '@polkadot/api';
+import type { ApiOptions } from '@polkadot/api/types';
 
 export interface DotApi {
   api?: ApiPromise;
   wsProvider?: WsProvider;
   keyring?: Keyring;
-  options?: any;
+  options?: ApiOptions;
   selectedEndpoint?: string;
 }
 

--- a/src/lib/stores/activityLogStore.ts
+++ b/src/lib/stores/activityLogStore.ts
@@ -65,8 +65,8 @@ export function parseActivity(
     } else {
       console.debug({ status });
     }
-  } catch (e: any) {
-    txnStatusItems.push('Error: ' + e.toString());
+  } catch (e: unknown) {
+    txnStatusItems.push('Error: ' + (e as Error).toString());
     txnStatus = TxnStatus.FAILURE;
   }
   return { txnStatusItems, txnStatus, txnId };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,8 +34,8 @@ export function isLocalhost(url: string): boolean {
   try {
     const parsedURL: URL = new URL(url);
     return parsedURL.hostname.includes('localhost') || parsedURL.hostname.includes('127.0.0.1');
-  } catch (e: any) {
-    console.error(e.toString());
+  } catch (e: unknown) {
+    console.error((e as Error).toString());
     return false;
   }
 }
@@ -44,8 +44,8 @@ export function isMainnet(url: string): boolean {
   try {
     const parsedURL: URL = new URL(url);
     return !!parsedURL.hostname.match(/^(0|1).rpc.frequency.xyz/)?.length;
-  } catch (e: any) {
-    console.error(e.toString());
+  } catch (e: unknown) {
+    console.error((e as Error).toString());
     return false;
   }
 }
@@ -94,7 +94,7 @@ export function createMailto(to: string, subject?: string, body?: string): strin
 }
 
 // Convert the provider name in hex to a human-readable value.
-export const providerNameToHuman = (name: any): string => {
+export const providerNameToHuman = (name: { toString: () => string }): string => {
   return hexToString(name.toString());
 };
 


### PR DESCRIPTION
## Goal

The goal of this PR is to turn on the lint error of explicit `any` types.

Parsed out while working on #187 

## Testing

`npm run lint` should now show no warnings or errors!