### PR TITLE
update styling on create msa

### DIFF
--- a/src/components/features/BecomeProviderNextSteps/CreateMsa.svelte
+++ b/src/components/features/BecomeProviderNextSteps/CreateMsa.svelte
@@ -38,7 +38,7 @@
     }
   };
 
-  run(() => {
+  $effect(() => {
     recentActivityItem = $activityLog.find((value) => value.txnId === recentTxnId);
     checkIsFinished();
   });
@@ -55,14 +55,15 @@
   };
 </script>
 
-<div id="create-msa" class="flex flex-col gap-3.5">
-  <div class="label">Create MSA Id</div>
+<div id="create-msa">
+  <div class="form-item-label">Create MSA Id</div>
   <p class="smText">
     An MSA (Message Source Account) is required to become a provider. This action will create an MSA Id that is
     controlled by the selected Transaction Signing Address above.
   </p>
-  {#if error}<div class="text-error text-sm font-bold">{error}</div>{/if}
-  <div class="flex w-[350px] items-end justify-between">
+  {#if error}<div class="text-error form-item-label">{error}</div>{/if}
+
+  <div class="mt-f16 flex w-[350px] items-end justify-between">
     <Button onclick={doCreateMsa} disabled={isInProgress}>
       {#if isInProgress}
         <LoadingIcon />
@@ -73,6 +74,7 @@
     <BackToRootButton />
   </div>
 </div>
+
 {#if recentActivityItem}
   <ActivityLogPreviewItem activity={recentActivityItem} />
 {/if}


### PR DESCRIPTION
## Goal

The goal of this PR is to make styling of the create msa section match the rest.

Closes #250 

## Discussion

- match styling
- match error styling

## Demo
<img width="746" height="454" alt="Screenshot 2025-08-20 at 11 38 13 AM" src="https://github.com/user-attachments/assets/7449cc17-0379-494e-af3e-7b63458af7b2" />
<img width="717" height="423" alt="Screenshot 2025-08-20 at 11 37 54 AM" src="https://github.com/user-attachments/assets/ac2d89b9-ec15-4653-bc47-8a289e543885" />
