### PR TITLE
Select network and account test coverage

### DIFF
--- a/src/components/features/SelectNetworkAndAccount/SelectNetwork.svelte
+++ b/src/components/features/SelectNetworkAndAccount/SelectNetwork.svelte
@@ -31,6 +31,7 @@
     isLoading = $bindable(false),
   }: Props = $props();
 
+  console.log('allNetworks', $allNetworks);
   // if there is a selected network from the store, use it
   onMount(async () => {
     if (selectedNetwork) {
@@ -101,7 +102,9 @@
   />
 {:else}
   <p class="gap-f8 flex items-center">
-    <IconButton label="switch button" onclick={resetState} disabled={isLoading}><Switch /></IconButton>
+    <IconButton data-testid="switch-button" label="switch button" onclick={resetState} disabled={isLoading}
+      ><Switch /></IconButton
+    >
     <span class="text-primary smText font-bold">Connected to {selectedNetwork?.name || 'Custom'}</span>
   </p>
 {/if}

--- a/src/components/features/SelectNetworkAndAccount/SelectNetworkAndAccount.svelte
+++ b/src/components/features/SelectNetworkAndAccount/SelectNetworkAndAccount.svelte
@@ -73,8 +73,7 @@
     }
   }
 
-  // export for testing purposes
-  export const resetState = () => {
+  const resetState = () => {
     selectedNetwork = null;
     selectedAccount = null;
     isCustomNetwork = false;

--- a/src/components/features/SelectNetworkAndAccount/SelectNetworkAndAccount.svelte
+++ b/src/components/features/SelectNetworkAndAccount/SelectNetworkAndAccount.svelte
@@ -50,7 +50,8 @@
     thisWeb3Accounts = polkadotExt.web3Accounts;
   });
 
-  async function connectAndFetchAccounts(network: NetworkInfo | null): Promise<void> {
+  // export only for testing purposes
+  export async function connectAndFetchAccounts(network: NetworkInfo | null): Promise<void> {
     if (network) {
       try {
         networkErrorMsg = '';
@@ -72,7 +73,8 @@
     }
   }
 
-  const resetState = () => {
+  // export for testing purposes
+  export const resetState = () => {
     selectedNetwork = null;
     selectedAccount = null;
     isCustomNetwork = false;

--- a/test/e2e/SelectNetworkAndAccount.test.ts
+++ b/test/e2e/SelectNetworkAndAccount.test.ts
@@ -1,0 +1,111 @@
+// ConnectAndFetchAccounts.test.ts
+import { getByText, render, waitFor } from '@testing-library/svelte';
+import { Mock, describe, expect, it, vi } from 'vitest';
+import SelectNetworkAndAccount from '../../src/components/features/SelectNetworkAndAccount/SelectNetworkAndAccount.svelte';
+import { createApi } from '../../src/lib/polkadotApi';
+import { Account, allAccountsStore, fetchAccountsForNetwork } from '../../src/lib/stores/accountsStore';
+import { NetworkInfo, NetworkType } from '../../src/lib/stores/networksStore';
+import { user } from '../../src/lib/stores/userStore';
+
+vi.mock('$lib/polkadotApi', () => ({
+  createApi: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock(import('$lib/stores/accountsStore'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchAccountsForNetwork: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('connectAndFetchAccounts', () => {
+  const mockAccount: Account = {
+    address: '0x123',
+    network: {
+      id: 'testnet',
+      name: 'testnet',
+      pathName: 'testnet',
+      endpoint: 'wss://test1.node',
+    },
+    msaId: 1,
+    isProvider: true,
+    balances: { transferable: 100n, locked: 0n, total: 100n },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allAccountsStore.set(new Map([[mockAccount.address, mockAccount]]));
+    user.set({ ...mockAccount });
+  });
+
+  it('sets networkErrorMsg when endpoint is missing', async () => {
+    const { container, component } = render(SelectNetworkAndAccount, {
+      props: {
+        newUser: null,
+        accounts: new Map(),
+      },
+    });
+
+    // invalid endpoint
+    await component.connectAndFetchAccounts({ name: 'testnet', endpoint: null });
+
+    expect(
+      getByText(container, 'Could not connect to empty value. Please enter a valid and reachable Websocket URL.')
+    ).toBeDefined();
+  });
+
+  it('sets successfully calls createApi and fetchAccountsForNetwork', async () => {
+    const disconnectMock = vi.fn();
+    (createApi as unknown as Mock).mockResolvedValue({
+      api: { disconnect: disconnectMock },
+    });
+
+    const { component } = render(SelectNetworkAndAccount, {
+      props: {
+        newUser: null,
+        accounts: allAccountsStore,
+      },
+    });
+
+    // valid endpoint
+    const validEndpoint: NetworkInfo = {
+      id: NetworkType.TESTNET_PASEO,
+      name: 'testnet',
+      endpoint: 'wss://test1.node',
+      pathName: 'testnet',
+    };
+    await component.connectAndFetchAccounts(validEndpoint);
+
+    await waitFor(() => {
+      expect(createApi).toBeCalledWith(validEndpoint.endpoint);
+      expect(fetchAccountsForNetwork).toBeCalled();
+      expect(disconnectMock).toBeCalled();
+    });
+  });
+
+  it('sets accountErrorMsg when account size is 0', async () => {
+    const disconnectMock = vi.fn();
+    (createApi as unknown as Mock).mockResolvedValue({
+      api: { disconnect: disconnectMock },
+    });
+
+    const { container, component } = render(SelectNetworkAndAccount, {
+      props: {
+        newUser: null,
+        accounts: new Map(),
+      },
+    });
+
+    // valid endpoint
+    const validEndpoint: NetworkInfo = {
+      id: NetworkType.TESTNET_PASEO,
+      name: 'testnet',
+      endpoint: 'wss://test1.node',
+      pathName: 'testnet',
+    };
+    await component.connectAndFetchAccounts(validEndpoint);
+
+    expect(getByText(container, 'No accounts found.')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Goal

The goal of this PR is to get full coverage on the component

part of #261 

## Discussion

- could not figure out how to do reset state. thing is that we're actually checking this already in `SelectNetwork.test.ts`.

## Checklist

- [ ] PR Self-Review and Commenting
- [ ] Docs updated
- [ ] Tests added

## How To Test the Changes

1. Clone the pr branch
2. run coverage
3. see tests pass
4. see close to full coverage
5. check to see if you have any ideas on how to cover that reset function
